### PR TITLE
feat: simplify CLI api for export

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ The `lola-sumup export` command:
 ```
 Consumes the (potentially redacted) intermediate file and exports to different special purpose CSV files
 
-Usage: lola-sumup export --intermediate-file <INTERMEDIATE_FILE>
+Usage: lola-sumup export <INTERMEDIATE_FILE>
+
+Arguments:
+  <INTERMEDIATE_FILE>  the intermediate file to process
 
 Options:
-  -i, --intermediate-file <INTERMEDIATE_FILE>  the intermediate file to process
-  -h, --help                                   Print help
-  -V, --version                                Print version
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 It produces three exports (with month and execution timestamp accordingly):

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,6 @@ enum Commands {
     /// Consumes the (potentially redacted) intermediate file and exports to different special purpose CSV files.
     Export {
         /// the intermediate file to process
-        #[arg(short, long)]
         intermediate_file: PathBuf,
     },
 }


### PR DESCRIPTION
`lola-sumup export <INTERMEDIATE-FILE>`

 instead of 

`lola-sumup export -i <INTERMEDIATE-FILE>`