### PR TITLE
feat: [#51] Columns for Income LoLa MiTi

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,11 @@ The columns of the resulting summary file are defined as follows:
   - `Gross MiTi (LoLa)`: Gross Income Mittagstisch with LoLa-items (Beverages...) (paid via Card or Cash)
   - `Gross MiTi (MiTi) Card`: Gross Income Mittagstisch from their own Menus (paid via Card only)
   - `Net MiTi (MiTi) Card `: Net Income Mittagstisch Menus w/o commission paid by card [`Gross MiTi (MiTi) Card` - `MiTi_Commission`]
-  - `Contribution LoLa`: Share MiTi from selling LoLa items [20% * (`Gross MiTi (LoLa)` - `LoLa_Commission_MiTi`)]
+  - `Net MiTi (LoLa) Card `: Net Income Mittagstisch with LoLa items w/o commission paid by card [`Net Card MiTi` - `Net MiTi (MiTi) Card`]
+  - `Net MiTi (LoLa)`: Net total income Mittagstisch with LoLa items w/o commission [`Gross MiTi (LoLa)` - `LoLa_Commission_MiTi`]
+  - `Contribution LoLa`: Share MiTi from selling LoLa items [20% * `Net MiTi (LoLa)`]
   - `Debt to MiTi`: Money from MiTi sales via Card w/o commission + contribution Lola sales + tips paid via Card [`Net MiTi (MiTi) Card` + `Contribution LoLa` + `MiTi_Tips_Card`]
+  - `Income LoLa MiTi`: Income LoLa from MiTi selling LoLa [`Net MiTi (LoLa) Card` - `Contribution LoLa`]
 - Statistics relevant for Mittagstisch:
   - `MealCount_Regular`: Number of regular meals per day
   - `MealCount_Children`: Number of children meals per day
@@ -183,13 +186,14 @@ The columns of the resulting accounting.csv file are defined as follows:
 - Generic columns
   - `Date`: [`Date`]
 - Debit statements in transitory account
-  - `Gross Card LoLa`: Total Gross Payments Card w/o MiTi
-  - `Net Card Total MiTi`: Net Card income + tips (card) Mittagstisch [`Net Card MiTi` + `MiTi_Tips_Card`]
-  - `Tips Card LoLa`: Tips LoLa paid via Card [`Tips_Card` - `MiTi_Tips_Card`]
+  - `Gross Card LoLa`: `10920/30200` - Total Gross Payments Card w/o MiTi
+  - `Net Card Total MiTi`: `10920/DLKMiti` - Net Card income + tips (card) Mittagstisch [`Net Card MiTi` + `MiTi_Tips_Card`]
+  - `Tips Card LoLa`: `10920/10910` - Tips LoLa paid via Card [`Tips_Card` - `MiTi_Tips_Card`]
 - Credit statements in transitory account
-  - `Payment SumUp`: Total Net Income plus tips paid via Card. Daily payment by SumUp (next business day) [`Net Card Total` + `Tips_Card`]
-  - `Commission LoLa`: Commission for Café and Vermietung, i.e. w/o Mittagstisch
+  - `Payment SumUp`: `10110/10920` - Total Net Income plus tips paid via Card. Daily payment by SumUp (next business day) [`Net Card Total` + `Tips_Card`]
+  - `Commission LoLa`: `68450/10920` - Commission for Café and Vermietung, i.e. w/o Mittagstisch
 - Debt to Mittagstisch
-  - `Debt to MiTi`: Amount LoLa owes to Mittagstisch (`Net Card MiTi` + `Contribution LoLa` + `Tips Due` or `Total Payment Due`)
+  - `Debt to MiTi`: `DLKMiti/10100` - Amount LoLa owes to Mittagstisch (`Net Card MiTi` + `Contribution LoLa` + `Tips Due` or `Total Payment Due`)
+  - `Income LoLa MiTi`: `DLKMiti/30200` - Income LoLa from MiTi selling LoLa [`Net MiTi (LoLa)` - `Contribution LoLa`]
 
 Where `Gross Card LoLa` + `Net Card MiTi` + `Tips Card LoLa` must be equal to `Payment Sumup` + `Commission LoLa`.

--- a/src/export/export_accounting.rs
+++ b/src/export/export_accounting.rs
@@ -29,6 +29,7 @@ pub fn gather_df_accounting(df: &DataFrame) -> PolarsResult<DataFrame> {
             col("Payment SumUp"),
             col("LoLa_Commission").alias("Commission LoLa"),
             col("Debt to MiTi"),
+            col("Income LoLa MiTi"),
         ])
         .collect()
 }
@@ -105,8 +106,13 @@ mod tests {
             "Gross MiTi (LoLa)" => &[Some(53.0)],
             "Gross MiTi (MiTi) Card" => &[Some(167.0)],
             "Net MiTi (MiTi) Card" => &[164.25],
+            "Net MiTi (LoLa) Card" => &[24.0],
+            "Net MiTi (LoLa)" => &[52.56],
             "Contribution LoLa" => &[10.51],
             "Debt to MiTi" => &[175.76],
+            "Income LoLa MiTi" => &[13.49],
+            "MealCount_Regular" => &[14],
+            "MealCount_Children" => &[3],
         )
         .expect("valid data frame");
         let expected = df!(
@@ -117,6 +123,7 @@ mod tests {
             "Payment SumUp" => &[220.21],
             "Commission LoLa" => &[Some(1.04)],
             "Debt to MiTi" => &[175.76],
+            "Income LoLa MiTi" => &[13.49],
         )
         .expect("valid data frame")
         .lazy()


### PR DESCRIPTION
Resolves #51

- adds `Income LoLa MiTi` to accounting report
- several related columns in summary reports
- improve coverage of test cases for summary report