### PR TITLE
feat: [#247] warn when encountring net price zero

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -12,6 +12,7 @@ use crate::export::constraint::{
 use crate::export::export_accounting::{gather_df_accounting, validate_acc_constraint};
 use crate::export::export_miti::gather_df_miti;
 use crate::export::export_summary::collect_data;
+use crate::prepare::warn_on_zero_value_trx;
 
 mod constraint;
 mod export_accounting;
@@ -28,6 +29,8 @@ pub fn export(input_path: &Path, month: &str, ts: &str) -> Result<(), Box<dyn Er
         .with_parse_options(parse_option)
         .try_into_reader_with_file_path(Some(input_path.into()))?
         .finish()?;
+
+    warn_on_zero_value_trx(&raw_df)?;
 
     let (mut df, mut df_acc) = crunch_data(raw_df)?;
 

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -369,7 +369,7 @@ fn infer_purpose() -> Expr {
 }
 
 // Outputs logs to console if one or more transactions with a net price 0.0 are found
-fn warn_on_zero_value_trx(df: &DataFrame) -> Result<(), Box<dyn Error>> {
+pub fn warn_on_zero_value_trx(df: &DataFrame) -> Result<(), Box<dyn Error>> {
     let violating = df
         .clone()
         .lazy()
@@ -380,9 +380,9 @@ fn warn_on_zero_value_trx(df: &DataFrame) -> Result<(), Box<dyn Error>> {
         )
         .collect()?;
     if violating.shape().0 > 0 {
-        println!("Records found with net price missing or 0.0:");
+        println!("Records found in intermediate document with net price missing or 0.0:");
         println!("{violating:?}");
-        println!("Please verify is this is correct and adjust input files or intermediate document if necessary.");
+        println!("Please verify is this is correct and adjust if necessary.");
     }
     Ok(())
 }

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -283,6 +283,7 @@ fn combine_input_dfs(sr_df: &DataFrame, txr_df: &DataFrame) -> Result<DataFrame,
             Expr::Literal(Null).alias("Comment"),
         ])
         .collect()?;
+    warn_on_zero_value_trx(&df)?;
     Ok(df)
 }
 
@@ -365,6 +366,25 @@ fn infer_purpose() -> Expr {
     when(col("Beschreibung").str().contains(lit("Trinkgeld"), true))
         .then(lit(Purpose::Tip.to_string()))
         .otherwise(lit(Purpose::Consumption.to_string()))
+}
+
+// Outputs logs to console if one or more transactions with a net price 0.0 are found
+fn warn_on_zero_value_trx(df: &DataFrame) -> Result<(), Box<dyn Error>> {
+    let violating = df
+        .clone()
+        .lazy()
+        .filter(
+            col("Price (Net)")
+                .eq(lit(0.0))
+                .or(col("Price (Net)").is_null()),
+        )
+        .collect()?;
+    if violating.shape().0 > 0 {
+        println!("Records found with net price missing or 0.0:");
+        println!("{violating:?}");
+        println!("Please verify is this is correct and adjust input files or intermediate document if necessary.");
+    }
+    Ok(())
 }
 
 //Different types of transactions, in data currently only Verkauf (`Sales`)


### PR DESCRIPTION
Warns (log out put to console), if
- when running step `prepare`, if any trx that will be written to the intermediate file has a net price of 0.0 or `null`
- when running step `export` , if any trx in the intermediate file has net price 0.0 or `null`.

Resolves #247