### PR TITLE
feat: [#266] Reclassification evening transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `lola-sumup` command has two subcommands:
 ```
 A cli program to create exports from sumup transactions exported in CSV format
 
-Usage: lola-sumup <COMMAND>
+mmmmmmmmmmmmmmmmmmmmmmmmmmm
 
 Commands:
   prepare  Prepares an enriched intermediate file from the original sumup sales report CSV and transaction report CSV
@@ -86,7 +86,10 @@ The four columns that may be modified are:
   - `Deposit`: Key deposit.
   - `Rental`: Rental fee.
   - `Culture`: Items sold in context of cultural events.
+               Automatically assigned if the transaction occurred after 18:00 --
+               if the description does not end with " (PO)".
   - `PaidOut`: Income paid out in cash to external party.
+               Automatically assigned if the transaction occurred after 18:00 and the description ends with " (PO)".
   - `Packaging`: Sold re-usable packaging for dishes
 - `Owner`: Only relevant for Topic `MiTi`: `MiTi` (for menus produced and sold by Mittagstisch) or `LoLa` (LoLa beverages and food from LoLa, sold by Mittagstisch)
 - `Purpose`: `Consumption` or `Tip` (the former is also used for Topics `Deposit`, `Rental`, `Culture`, or `PaidOut`)

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -252,7 +252,7 @@ fn combine_input_dfs(sr_df: &DataFrame, txr_df: &DataFrame) -> Result<DataFrame,
         )
         .with_column(infer_payment_method().alias("Payment Method"))
         .with_column(infer_type().alias("Type"))
-        .with_column(infer_topic(time_format).alias("Topic"))
+        .with_column(infer_topic(&time_format).alias("Topic"))
         .join(
             commission_df,
             [col("Transaktionsnummer")],
@@ -305,7 +305,7 @@ fn infer_payment_method() -> Expr {
 /// between 14:15 and 18:00 -> `Cafe`
 /// after 18:00 -> `Culture` or `PaidOut` if description ends with " (PO)".
 /// If the description starts with "Recircle Tupper Depot", the topic will be `Packaging` regardless of time od day.
-fn infer_topic(time_options: StrptimeOptions) -> Expr {
+fn infer_topic(time_options: &StrptimeOptions) -> Expr {
     when(
         col("Beschreibung")
             .str()


### PR DESCRIPTION
Resolves #266.

Instead of assigning topic `Verm` for transactions after 18:00, we now use `Culture`, which is much more often the correct choice. If the description ends with " (PO)", we use `PaidOut` instead.