### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/jococo-ch/lola-sumup/compare/v0.4.1...v0.4.2) - 2026-04-13
+
+### Fixed
+
+- have release-plz rely on git only and not cargo registry at all
+- nudge release-plz to not compare content with the cargo registry
+
+### Other
+
+- release v0.4.1 ([#525](https://github.com/jococo-ch/lola-sumup/pull/525))
+
 ## [0.4.1](https://github.com/jococo-ch/lola-sumup/compare/v0.1.0...v0.4.1) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lola-sumup"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lola-sumup"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Urs Joss <urs.joss@gmx.ch>"]
 edition = "2024"
 description = "A cli program to create LoLa specific exports from monthly SumUp reports"


### PR DESCRIPTION



## 🤖 New release

* `lola-sumup`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/jococo-ch/lola-sumup/compare/v0.4.1...v0.4.2) - 2026-04-13

### Fixed

- have release-plz rely on git only and not cargo registry at all
- nudge release-plz to not compare content with the cargo registry

### Other

- release v0.4.1 ([#525](https://github.com/jococo-ch/lola-sumup/pull/525))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).