### PR TITLE
chore: release v0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lola-sumup"
-version = "0.4.1"
+version = "0.4.2"
 publish = false
 authors = ["Urs Joss <urs.joss@gmx.ch>"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `lola-sumup`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/jococo-ch/lola-sumup/compare/v0.4.1...v0.4.2) - 2026-04-13

### Fixed

- have release-plz rely on git only and not cargo registry at all
- nudge release-plz to not compare content with the cargo registry

### Other

- release v0.4.1 ([#525](https://github.com/jococo-ch/lola-sumup/pull/525))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).