### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/jococo-ch/lola-sumup/compare/v0.4.2...v0.4.3) - 2026-04-13
+
+### Fixed
+
+- Dummy change to trigger release
+
 ## [0.4.2](https://github.com/jococo-ch/lola-sumup/compare/v0.4.1...v0.4.2) - 2026-04-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lola-sumup"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lola-sumup"
-version = "0.4.2"
+version = "0.4.3"
 publish = false
 authors = ["Urs Joss <urs.joss@gmx.ch>"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `lola-sumup`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/jococo-ch/lola-sumup/compare/v0.4.2...v0.4.3) - 2026-04-13

### Fixed

- Dummy change to trigger release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).