### PR TITLE
chore: release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/jococo-ch/lola-sumup/compare/v0.4.5...v0.4.6) - 2026-04-14
+
+### Other
+
+- *(deps)* bump rand from 0.9.2 to 0.9.4 in the cargo group across 1 directory ([#533](https://github.com/jococo-ch/lola-sumup/pull/533))
+
 ## [0.4.5](https://github.com/jococo-ch/lola-sumup/compare/v0.4.4...v0.4.5) - 2026-04-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lola-sumup"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lola-sumup"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Urs Joss <urs.joss@gmx.ch>"]
 edition = "2024"
 description = "A cli program to create LoLa specific exports from monthly SumUp reports"


### PR DESCRIPTION



## 🤖 New release

* `lola-sumup`: 0.4.5 -> 0.4.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.6](https://github.com/jococo-ch/lola-sumup/compare/v0.4.5...v0.4.6) - 2026-04-14

### Other

- *(deps)* bump rand from 0.9.2 to 0.9.4 in the cargo group across 1 directory ([#533](https://github.com/jococo-ch/lola-sumup/pull/533))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).