### PR TITLE
chore: release v0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9](https://github.com/jococo-ch/lola-sumup/compare/v0.4.8...v0.4.9) - 2026-04-14
+
+### Fixed
+
+- changelog groups in release pages
+
 ## [0.4.8](https://github.com/jococo-ch/lola-sumup/compare/v0.4.7...v0.4.8) - 2026-04-14
 
 ### ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lola-sumup"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lola-sumup"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Urs Joss <urs.joss@gmx.ch>"]
 edition = "2024"
 description = "A cli program to create LoLa specific exports from monthly SumUp reports"


### PR DESCRIPTION



## 🤖 New release

* `lola-sumup`: 0.4.8 -> 0.4.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.9](https://github.com/jococo-ch/lola-sumup/compare/v0.4.8...v0.4.9) - 2026-04-14

### Fixed

- changelog groups in release pages
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).