### PR TITLE
chore: release v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11](https://github.com/jococo-ch/lola-sumup/compare/v0.4.10...v0.4.11) - 2026-07-12
+
+### Other
+
+- Bump cargo-dist to 0.32.0
+- Fix formatting in CHANGELOG.md headings
+
+### Refactored
+
+- clippy suggestion collapsible_match
+
 ## [0.4.10](https://github.com/jococo-ch/lola-sumup/compare/v0.4.9...v0.4.10) - 2026-05-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lola-sumup"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lola-sumup"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Urs Joss <urs.joss@gmx.ch>"]
 edition = "2024"
 description = "A cli program to create LoLa specific exports from monthly SumUp reports"


### PR DESCRIPTION



## 🤖 New release

* `lola-sumup`: 0.4.10 -> 0.4.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.11](https://github.com/jococo-ch/lola-sumup/compare/v0.4.10...v0.4.11) - 2026-07-12

### Other

- Bump cargo-dist to 0.32.0
- Fix formatting in CHANGELOG.md headings

### Refactored

- clippy suggestion collapsible_match
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).