### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/jococo-ch/lola-sumup/compare/v0.5.0...v0.5.1) - 2026-08-05
+
+### Fixed
+
+- [#572] Log table exports (prepare and export) and skip writing an export that would fail with 0 rows ([#573](https://github.com/jococo-ch/lola-sumup/pull/573))
+
 ## [0.5.0](https://github.com/jococo-ch/lola-sumup/compare/v0.4.10...v0.5.0) - 2026-07-12
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,7 +1392,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lola-sumup"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "calamine",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lola-sumup"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Urs Joss <urs.joss@gmx.ch>"]
 edition = "2024"
 description = "A cli program to create LoLa specific exports from monthly SumUp reports"


### PR DESCRIPTION



## 🤖 New release

* `lola-sumup`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/jococo-ch/lola-sumup/compare/v0.5.0...v0.5.1) - 2026-08-05

### Fixed

- [#572] Log table exports (prepare and export) and skip writing an export that would fail with 0 rows ([#573](https://github.com/jococo-ch/lola-sumup/pull/573))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).